### PR TITLE
Try fix mods with incorrect folders structures - please test if its working all right xD

### DIFF
--- a/UnleashTheMods/Program.cs
+++ b/UnleashTheMods/Program.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using SharpCompress.Archives;
 using SharpCompress.Common;
+using SharpCompress.Writers;
 
 public class ScriptFile
 {
@@ -23,10 +24,12 @@ class Program
     {
         Console.Title = "Unleash The Mods - Mod Merge Utility";
         Console.WriteLine("By MetalHeadbang a.k.a @unsc.odst");
+
         string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
         string sourceDirectory = Path.Combine(baseDirectory, "source");
         string modsDirectory = Path.Combine(baseDirectory, "mods");
         string stagingDirectory = Path.Combine(baseDirectory, "staging_area");
+        string fixedModsDirectory = Path.Combine(baseDirectory, "fixed_mods"); // Folder for fixed mods
 
         if (!Directory.Exists(sourceDirectory) || !Directory.Exists(modsDirectory))
         {
@@ -37,16 +40,30 @@ class Program
             return;
         }
 
-        Console.WriteLine($"'source' and 'mods' folders found.\n");
-        var sourcePaks = Directory.GetFiles(sourceDirectory, "*.pak");
+        Console.WriteLine("'source' and 'mods' folders found.\n");
 
+        // Verify and fix mod folder structures
+        string gamePakPath = Path.Combine(sourceDirectory, "data0.pak");
+        if (!File.Exists(gamePakPath))
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("\nERROR: 'data0.pak' not found in source folder!");
+            Console.ResetColor();
+            Console.ReadKey();
+            return;
+        }
+
+        Directory.CreateDirectory(fixedModsDirectory);
+        var validMods = FixModStructures(gamePakPath, modsDirectory, fixedModsDirectory);
+
+        var sourcePaks = Directory.GetFiles(sourceDirectory, "*.pak");
         List<ScriptFile> originalScripts = LoadScriptsFromPakFiles(sourcePaks);
         Console.WriteLine($"{originalScripts.Count} scripts loaded from original game packages.");
 
-        List<ScriptFile> moddedScripts = LoadAllScriptsFromModsFolder(modsDirectory);
+        List<ScriptFile> moddedScripts = LoadAllScriptsFromModsFolder(validMods); // Use valid mods
         Console.WriteLine($"{moddedScripts.Count} scripts loaded from the mods folder.\n");
-        Console.WriteLine("---  Merging Initializing ---");
 
+        Console.WriteLine("--- Merging Initializing ---");
         var modFileGroups = moddedScripts.GroupBy(s => s.FullPathInPak)
                                          .ToDictionary(g => g.Key, g => g.ToList());
 
@@ -74,20 +91,19 @@ class Program
 
         Console.WriteLine("\n\n--- Merge Completed ---");
         Console.WriteLine($"{finalFileContents.Count} modded files are ready to be packaged.");
-
         Console.WriteLine("\n--- Creating .pak File ---");
 
         if (Directory.Exists(stagingDirectory)) Directory.Delete(stagingDirectory, true);
         Directory.CreateDirectory(stagingDirectory);
 
         var safeEncoding = new UTF8Encoding(false);
-
         foreach (var fileEntry in finalFileContents)
         {
             string fullPath = Path.Combine(stagingDirectory, fileEntry.Key);
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
             File.WriteAllText(fullPath, fileEntry.Value, safeEncoding);
         }
+
         Console.WriteLine($"{finalFileContents.Count} files packing");
 
         int nextPakNum = 0;
@@ -100,8 +116,8 @@ class Program
                 if (num >= nextPakNum) nextPakNum = num + 1;
             }
         }
-        if (nextPakNum < 3) nextPakNum = 3;
 
+        if (nextPakNum < 3) nextPakNum = 3;
         string finalPakPath = Path.Combine(sourceDirectory, $"data{nextPakNum}.pak");
         if (File.Exists(finalPakPath)) File.Delete(finalPakPath);
 
@@ -112,9 +128,205 @@ class Program
         Console.ResetColor();
 
         Directory.Delete(stagingDirectory, true);
-
         Console.WriteLine("\nPress any key to exit...");
         Console.ReadKey();
+    }
+
+    // Fix mod folder structures to match data0.pak
+    static List<string> FixModStructures(string gamePakPath, string modsDirectory, string fixedModsDirectory)
+    {
+        var fileStructure = GetGameFileStructure(gamePakPath);
+        var validMods = new List<string>();
+        var supportedExtensions = new[] { ".pak", ".zip", ".rar", ".7z" };
+        var modFiles = Directory.GetFiles(modsDirectory)
+                                .Where(f => supportedExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()));
+
+        foreach (var modFile in modFiles)
+        {
+            bool needsFixing = false;
+            string modName = Path.GetFileNameWithoutExtension(modFile);
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            string fixedPakPath = Path.Combine(tempDir, "fixed.pak");
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                List<(string Name, string Path, Stream Content)> modScripts = new List<(string, string, Stream)>();
+                List<string> unknownFiles = new List<string>();
+
+                // Process mod
+                if (Path.GetExtension(modFile).ToLowerInvariant() == ".pak")
+                {
+                    modScripts = ReadScriptsFromSinglePakForFixing(modFile, ref needsFixing, fileStructure, ref unknownFiles);
+                }
+                else
+                {
+                    using (var archive = ArchiveFactory.Open(modFile))
+                    {
+                        foreach (var entry in archive.Entries)
+                        {
+                            if (!entry.IsDirectory && entry.Key.EndsWith(".pak", StringComparison.OrdinalIgnoreCase))
+                            {
+                                using (var pakEntryStream = entry.OpenEntryStream())
+                                using (var memoryStream = new MemoryStream())
+                                {
+                                    pakEntryStream.CopyTo(memoryStream);
+                                    memoryStream.Position = 0;
+                                    modScripts = ReadScriptsFromSinglePakForFixing(memoryStream, ref needsFixing, fileStructure, ref unknownFiles);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Handle files not found in data0.pak
+                if (unknownFiles.Any())
+                {
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($"\nWARNING: Mod '{modName}' contains files not found in data0.pak:");
+                    foreach (var file in unknownFiles)
+                    {
+                        Console.WriteLine($" - {file}");
+                    }
+                    Console.WriteLine("Options: (1) Keep original structure, (2) Exclude this mod.");
+                    Console.Write("Please select an option (1 or 2): ");
+                    string input = Console.ReadLine()?.Trim().ToLowerInvariant() ?? "2";
+                    Console.ResetColor();
+
+                    if (input != "1")
+                    {
+                        Console.WriteLine($"Mod '{modName}' excluded due to unknown files.");
+                        continue; // Skip this mod
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Mod '{modName}' will be used with its original structure.");
+                        validMods.Add(modFile);
+                        continue;
+                    }
+                }
+
+                if (needsFixing)
+                {
+                    // Create fixed .pak
+                    using (var fixedPakStream = File.OpenWrite(fixedPakPath))
+                    using (var writer = WriterFactory.Open(fixedPakStream, ArchiveType.Zip, new WriterOptions(CompressionType.Deflate)))
+                    {
+                        foreach (var (fileName, correctPath, contentStream) in modScripts)
+                        {
+                            contentStream.Position = 0;
+                            writer.Write(correctPath.Replace('\\', '/'), contentStream);
+                        }
+                    }
+
+                    // Create new ZIP with the fixed .pak
+                    string fixedZipPath = Path.Combine(fixedModsDirectory, $"{modName}_fixed.zip");
+                    using (var fixedZipStream = File.OpenWrite(fixedZipPath))
+                    using (var writer = WriterFactory.Open(fixedZipStream, ArchiveType.Zip, new WriterOptions(CompressionType.Deflate)))
+                    {
+                        writer.Write("mod.pak", fixedPakPath);
+                    }
+                    validMods.Add(fixedZipPath);
+                    Console.WriteLine($"Mod '{modName}' fixed and saved as '{Path.GetFileName(fixedZipPath)}'.");
+                }
+                else
+                {
+                    validMods.Add(modFile);
+                    Console.WriteLine($"Mod '{modName}' already has correct folder structure.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.ForegroundColor = ConsoleColor.DarkRed;
+                Console.WriteLine($"ERROR: Could not process mod '{modName}'. Reason: {ex.Message}");
+                Console.ResetColor();
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, true);
+            }
+        }
+
+        return validMods;
+    }
+
+    // Map folder structure of data0.pak
+    static Dictionary<string, string> GetGameFileStructure(string gamePakPath)
+    {
+        var structure = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        using (var archive = ArchiveFactory.Open(gamePakPath))
+        {
+            foreach (var entry in archive.Entries)
+            {
+                if (!entry.IsDirectory && entry.Key.EndsWith(".scr", StringComparison.OrdinalIgnoreCase))
+                {
+                    string fileName = Path.GetFileName(entry.Key);
+                    string fullPath = entry.Key.Replace("/", "\\");
+                    if (!structure.ContainsKey(fileName))
+                    {
+                        structure[fileName] = fullPath;
+                    }
+                    else
+                    {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine($"Warning: Duplicate file '{fileName}' found at '{fullPath}' in data0.pak.");
+                        Console.ResetColor();
+                    }
+                }
+            }
+        }
+        return structure;
+    }
+
+    // Read scripts from a .pak and check if fixing is needed
+    static List<(string Name, string Path, Stream Content)> ReadScriptsFromSinglePakForFixing(Stream pakStream, ref bool needsFixing, Dictionary<string, string> fileStructure, ref List<string> unknownFiles)
+    {
+        var scripts = new List<(string Name, string Path, Stream Content)>();
+        using (var pakArchive = ArchiveFactory.Open(pakStream))
+        {
+            foreach (var entry in pakArchive.Entries)
+            {
+                if (!entry.IsDirectory && entry.Key.EndsWith(".scr", StringComparison.OrdinalIgnoreCase))
+                {
+                    string fileName = Path.GetFileName(entry.Key);
+                    string fullPath = entry.Key.Replace("/", "\\");
+                    string correctPath = fullPath;
+
+                    // Check if file is in root (no subfolders)
+                    if (!fullPath.Contains("\\") || fullPath == fileName)
+                    {
+                        needsFixing = true;
+                        if (fileStructure.TryGetValue(fileName, out var path))
+                        {
+                            correctPath = path;
+                        }
+                        else
+                        {
+                            unknownFiles.Add(fullPath);
+                            continue; // Skip this file for now, handle later via user input
+                        }
+                    }
+
+                    using (var entryStream = entry.OpenEntryStream())
+                    {
+                        var memoryStream = new MemoryStream();
+                        entryStream.CopyTo(memoryStream);
+                        memoryStream.Position = 0;
+                        scripts.Add((fileName, correctPath, memoryStream));
+                    }
+                }
+            }
+        }
+        return scripts;
+    }
+
+    static List<(string Name, string Path, Stream Content)> ReadScriptsFromSinglePakForFixing(string pakPath, ref bool needsFixing, Dictionary<string, string> fileStructure, ref List<string> unknownFiles)
+    {
+        using (var stream = File.OpenRead(pakPath))
+        {
+            return ReadScriptsFromSinglePakForFixing(stream, ref needsFixing, fileStructure, ref unknownFiles);
+        }
     }
 
     static string? TryParseKey(string line)
@@ -150,7 +362,6 @@ class Program
 
         var finalContent = new StringBuilder();
         var originalLines = original.Content.Replace("\r\n", "\n").Split('\n');
-
         var resolutions = new Dictionary<string, string>();
         string? preferredModSource = null;
         int autoResolvedCount = 0;
@@ -158,7 +369,6 @@ class Program
         foreach (var originalLine in originalLines)
         {
             var key = TryParseKey(originalLine);
-
             if (key == null)
             {
                 finalContent.AppendLine(originalLine);
@@ -173,7 +383,6 @@ class Program
 
             var actualChanges = new List<(string Line, string SourcePak)>();
             originalMap.TryGetValue(key, out var baseLine);
-
             foreach (var mod in modMaps)
             {
                 if (mod.Map.TryGetValue(key, out var modLine) && modLine != baseLine)
@@ -196,7 +405,6 @@ class Program
                 var distinctChanges = actualChanges.GroupBy(v => v.Line)
                                                    .Select(g => (Line: g.Key, Sources: g.Select(v => v.SourcePak).ToList()))
                                                    .ToList();
-
                 if (distinctChanges.Count == 1)
                 {
                     finalContent.AppendLine(distinctChanges[0].Line);
@@ -204,67 +412,50 @@ class Program
                 }
                 else
                 {
-                    string chosenLine;
-                    if (preferredModSource != null)
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"\n[CHOICE REQUIRED] Conflict in '{original.FullPathInPak}'!");
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($" -> Conflict for key '{key}':");
+                    Console.ResetColor();
+                    for (int i = 0; i < distinctChanges.Count; i++)
                     {
-                        var preferredVersion = distinctChanges.FirstOrDefault(v => v.Sources.Contains(preferredModSource));
-                        chosenLine = preferredVersion.Line ?? distinctChanges[0].Line;
-                        autoResolvedCount++;
-                    }
-                    else
-                    {
-                        Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine($"\n[CHOICE REQUIRED] Conflict in '{original.FullPathInPak}'!");
+                        string sources = string.Join(", ", distinctChanges[i].Sources);
+                        Console.Write($" {i + 1}. (");
                         Console.ForegroundColor = ConsoleColor.Yellow;
-                        Console.WriteLine($"  -> Conflict for key '{key}':");
+                        Console.Write(sources);
                         Console.ResetColor();
-
-                        for (int i = 0; i < distinctChanges.Count; i++)
-                        {
-                            string sources = string.Join(", ", distinctChanges[i].Sources);
-                            Console.Write($"    {i + 1}. (");
-                            Console.ForegroundColor = ConsoleColor.Yellow;
-                            Console.Write(sources);
-                            Console.ResetColor();
-                            Console.Write("): ");
-                            Console.ForegroundColor = ConsoleColor.Cyan;
-                            Console.WriteLine(distinctChanges[i].Line.Trim());
-                            Console.ResetColor();
-                        }
-
-                        Console.WriteLine("   To prefer a mod for all conflicts in this file, add 'y' to your choice (e.g., '1y') (CAREFUL! THIS IS FOR ADVANCED USERS).");
-
-                        int choice = -1;
-                        string? chosenSource = null;
-                        while (choice < 1 || choice > distinctChanges.Count)
-                        {
-                            Console.Write($"Please select the version to use (1-{distinctChanges.Count}): ");
-                            string? input = Console.ReadLine()?.ToLowerInvariant();
-
-                            if (input != null && input.EndsWith("y"))
-                            {
-                                if (int.TryParse(input.TrimEnd('y'), out choice) && choice >= 1 && choice <= distinctChanges.Count)
-                                {
-                                    chosenSource = distinctChanges[choice - 1].Sources.First();
-                                }
-                            }
-                            else
-                            {
-                                int.TryParse(input, out choice);
-                            }
-                        }
-
-                        chosenLine = distinctChanges[choice - 1].Line;
-                        if (chosenSource != null)
-                        {
-                            preferredModSource = chosenSource;
-                        }
-
-                        Console.ForegroundColor = ConsoleColor.Green;
-                        Console.WriteLine("  -> Choice applied.");
+                        Console.Write("): ");
+                        Console.ForegroundColor = ConsoleColor.Cyan;
+                        Console.WriteLine(distinctChanges[i].Line.Trim());
                         Console.ResetColor();
                     }
-
+                    Console.WriteLine(" To prefer a mod for all conflicts in this file, add 'y' to your choice (e.g., '1y') (CAREFUL! THIS IS FOR ADVANCED USERS).");
+                    int choice = -1;
+                    string? chosenSource = null;
+                    while (choice < 1 || choice > distinctChanges.Count)
+                    {
+                        Console.Write($"Please select the version to use (1-{distinctChanges.Count}): ");
+                        string? input = Console.ReadLine()?.ToLowerInvariant();
+                        if (input != null && input.EndsWith("y"))
+                        {
+                            if (int.TryParse(input.TrimEnd('y'), out choice) && choice >= 1 && choice <= distinctChanges.Count)
+                            {
+                                chosenSource = distinctChanges[choice - 1].Sources.First();
+                            }
+                        }
+                        else
+                        {
+                            int.TryParse(input, out choice);
+                        }
+                    }
+                    string chosenLine = distinctChanges[choice - 1].Line;
+                    if (chosenSource != null)
+                    {
+                        preferredModSource = chosenSource;
+                    }
+                    Console.ForegroundColor = ConsoleColor.Green;
+                    Console.WriteLine(" -> Choice applied.");
+                    Console.ResetColor();
                     finalContent.AppendLine(chosenLine);
                     resolutions[key] = chosenLine;
                 }
@@ -281,12 +472,10 @@ class Program
         return finalContent.ToString();
     }
 
-    static List<ScriptFile> LoadAllScriptsFromModsFolder(string modsDirectory)
+    static List<ScriptFile> LoadAllScriptsFromModsFolder(IEnumerable<string> modFiles)
     {
         var allScripts = new List<ScriptFile>();
         var supportedExtensions = new[] { ".pak", ".zip", ".rar", ".7z" };
-        var modFiles = Directory.GetFiles(modsDirectory)
-                                .Where(f => supportedExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()));
 
         foreach (var modFilePath in modFiles)
         {
@@ -306,13 +495,11 @@ class Program
                             if (!entry.IsDirectory && entry.Key.EndsWith(".pak", StringComparison.OrdinalIgnoreCase))
                             {
                                 using (var pakEntryStream = entry.OpenEntryStream())
+                                using (var memoryStream = new MemoryStream())
                                 {
-                                    using (var memoryStream = new MemoryStream())
-                                    {
-                                        pakEntryStream.CopyTo(memoryStream);
-                                        memoryStream.Position = 0;
-                                        allScripts.AddRange(ReadScriptsFromSinglePak(memoryStream, sourceName));
-                                    }
+                                    pakEntryStream.CopyTo(memoryStream);
+                                    memoryStream.Position = 0;
+                                    allScripts.AddRange(ReadScriptsFromSinglePak(memoryStream, sourceName));
                                 }
                             }
                         }
@@ -326,6 +513,7 @@ class Program
                 Console.ResetColor();
             }
         }
+
         return allScripts;
     }
 


### PR DESCRIPTION
The updated code (provided in the previous response) includes the following changes:

New Function: FixModStructures:

Purpose: Verifies the folder structure of each mod's .pak against data0.pak and fixes incorrect structures. Process:

Maps the folder structure of data0.pak using GetGameFileStructure, creating a dictionary of .scr filenames to their full paths (e.g., player.scr -> scripts/game/player.scr). Processes each mod in mods/:

For .pak files, directly checks the .scr files inside. For ZIP/RAR/7z, extracts the .pak and checks its .scr files. Uses ReadScriptsFromSinglePakForFixing to collect .scr files and detect if any are in the root (no subfolders). If a .scr file is not found in data0.pak, adds it to unknownFiles and prompts the user later. If fixing is needed (root files or incorrect paths), creates a new .pak with corrected paths and packages it into <mod_name>_fixed.zip in fixed_mods/. If the structure is correct, uses the original mod file.

For mods with unknown files:

Displays a warning listing the files (e.g., WARNING: Mod 'modName' contains files not found in data0.pak:). Prompts: Options: (1) Keep original structure, (2) Exclude this mod. If the user selects 1, adds the original mod to validMods. If 2 (or any other input), skips the mod.

Returns a list of valid mod paths (validMods).

Output: Saves fixed mods as <mod_name>_fixed.zip in fixed_mods/ and logs actions (e.g., "Mod 'modName' fixed and saved as 'modName_fixed.zip'.").

New Function: GetGameFileStructure:

Reads data0.pak and builds a dictionary of .scr filenames to their full paths. Logs warnings for duplicate filenames (e.g., "Warning: Duplicate file 'player.scr' found at 'scripts/other/player.scr' in data0.pak."). Uses StringComparer.OrdinalIgnoreCase for case-insensitive matching.

New Function: ReadScriptsFromSinglePakForFixing:

Similar to ReadScriptsFromSinglePak, but returns a list of tuples (Name, Path, Content) for .scr files. Checks if files are in the root (e.g., player.scr with no subfolders) and sets needsFixing = true. For root files, infers the correct path from fileStructure or adds to unknownFiles if not found. Stores content in a MemoryStream for use in creating the fixed .pak.

Main Method Modifications:

Adds fixed_mods/ folder creation and data0.pak existence check. Calls FixModStructures before loading mod scripts, passing the resulting validMods to LoadAllScriptsFromModsFolder. Ensures only valid mods (originals with correct structure or fixed ones) are processed.

Modified LoadAllScriptsFromModsFolder:

Changed to accept an IEnumerable<string> (list of valid mod paths) instead of scanning mods/ directly. Processes only the mods in validMods, ensuring fixed or correct mods are used.

English Localization:

All console messages, logs, and comments are now in English. Examples:

"ERROR: 'source' and 'mods' folders not found!"
"Mod 'modName' already has correct folder structure." Comments: e.g., // Map folder structure of data0.pak.

Handling Unknown Files:

If a mod's .scr file is not found in data0.pak, it's added to unknownFiles. After processing the mod, if unknownFiles is not empty:

Lists the files and prompts the user to choose between keeping the original structure or excluding the mod. Default (non-1 input) excludes the mod.

SharpCompress Usage:

Uses ArchiveFactory to read .pak (ZIP) and mod archives (ZIP, RAR, 7z). Uses WriterFactory with ArchiveType.Zip and CompressionType.Deflate to create fixed .pak files and <mod_name>_fixed.zip.

How to Use the Updated Code

Folder Setup:

Place the game's data0.pak in the source/ folder.
Place mod files (.pak, ZIP, RAR, or 7z) in the mods/ folder. The fixed_mods/ folder will be created automatically to store <mod_name>_fixed.zip files.

Execution Flow:

The program checks source/ and mods/ for existence and ensures data0.pak is present. FixModStructures processes each mod:

Verifies the .pak's .scr files against data0.pak's structure. Fixes root files by moving them to the correct paths (e.g., player.scr -> scripts/game/player.scr). For .scr files not in data0.pak, prompts:
text